### PR TITLE
Implement rootPathPrefix support for feign-ranger

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>feign.ranger</groupId>
     <artifactId>feign-ranger</artifactId>
-    <version>0.1.7</version>
+    <version>0.1.8</version>
     <packaging>jar</packaging>
 
     <name>feign-ranger</name>

--- a/src/test/java/feign/ranger/FeignRangerFallbackAddressTest.java
+++ b/src/test/java/feign/ranger/FeignRangerFallbackAddressTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2016 Phaneesh Nagaraja <phaneesh.n@gmail.com>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package feign.ranger;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import feign.*;
+import feign.jackson.JacksonDecoder;
+import feign.jackson.JacksonEncoder;
+import lombok.*;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.retry.RetryForever;
+import org.apache.curator.test.TestingCluster;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.junit.Assert.*;
+
+/**
+ * Unit test for simple App.
+ */
+@Slf4j
+public class FeignRangerFallbackAddressTest {
+
+    private static String FALLBACK_ADDRESS = "fallback-address:9999";
+
+    private static String ROOT_PATH_PREFIX = "apis/ks";
+
+    private TestingCluster testingCluster;
+
+    private CuratorFramework curator;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private final Logger.ErrorLogger logger = new Logger.ErrorLogger();
+
+    @Rule
+    public WireMockRule wireMockRule = new WireMockRule(9999);
+
+    @Before
+    public void startTestCluster() throws Exception {
+
+        testingCluster = new TestingCluster(1);
+        testingCluster.start();
+        curator = CuratorFrameworkFactory.builder()
+                .connectString(testingCluster.getConnectString())
+                .namespace("test")
+                .retryPolicy(new RetryForever(3000))
+                .build();
+        curator.start();
+    }
+
+    @After
+    public void stopTestCluster() throws Exception {
+        if(null != curator) {
+            curator.close();
+        }
+        if(null != testingCluster) {
+            testingCluster.close();
+        }
+
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testFallbackApplyCallFail() throws Exception {
+        stubFor(get(urlEqualTo("/v1/test"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withBody(objectMapper.writeValueAsBytes(
+                                TestResponse.builder()
+                                        .message("test")
+                                        .build()
+                        ))
+                        .withHeader("Content-Type", "application/json")));
+        TestApi api = Feign.builder()
+                .decoder(new JacksonDecoder())
+                .encoder(new JacksonEncoder())
+                .logger(logger)
+                .logLevel(Logger.Level.FULL)
+                .target(RangerTarget.<TestApi>builder().type(TestApi.class).environment("test").namespace("test").service("test").curator(curator).objectMapper(objectMapper).fallbackAddress("127.0.0.1:9999").build());
+        val result = api.test();
+        assertTrue(result.message.equalsIgnoreCase("test"));
+    }
+
+    @Test
+    public void testFallbackUrlCall() throws Exception {
+        val target = RangerTarget.<TestApi>builder().type(TestApi.class).environment("test").namespace("test").service("test").curator(curator).objectMapper(objectMapper).fallbackAddress(FALLBACK_ADDRESS).build();
+        assertEquals("http://" + FALLBACK_ADDRESS, target.url());
+    }
+
+    @Test
+    public void testFallbackrootPathPrefixUrlCall() throws Exception {
+        val target = RangerTarget.<TestApi>builder().type(TestApi.class).environment("test").namespace("test").service("test").curator(curator).objectMapper(objectMapper).fallbackAddress(FALLBACK_ADDRESS).rootPathPrefix(ROOT_PATH_PREFIX).build();
+        assertEquals("http://" + FALLBACK_ADDRESS + "/" + ROOT_PATH_PREFIX, target.url());
+    }
+
+    @Test
+    public void testFallbackrootPathPrefixHttpsUrlCall() throws Exception {
+        val target = RangerTarget.<TestApi>builder().type(TestApi.class).environment("test").namespace("test").service("test").curator(curator).secured(true).objectMapper(objectMapper).fallbackAddress(FALLBACK_ADDRESS).rootPathPrefix(ROOT_PATH_PREFIX).build();
+        assertEquals("https://" + FALLBACK_ADDRESS + "/" + ROOT_PATH_PREFIX, target.url());
+    }
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    static class TestResponse {
+
+        private String message;
+    }
+
+    interface TestApi {
+
+        @RequestLine("GET /v1/test")
+        TestResponse test();
+    }
+}

--- a/src/test/java/feign/ranger/FeignRangerHttpTest.java
+++ b/src/test/java/feign/ranger/FeignRangerHttpTest.java
@@ -139,6 +139,27 @@ public class FeignRangerHttpTest {
     }
 
     @Test
+    public void testSuccessfulHttpRootPathPrefixCall() throws Exception {
+        stubFor(get(urlEqualTo("/apis/ks/v1/test"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withBody(objectMapper.writeValueAsBytes(
+                                TestResponse.builder()
+                                        .message("test")
+                                        .build()
+                        ))
+                        .withHeader("Content-Type", "application/json")));
+        TestApi api = Feign.builder()
+                .decoder(new JacksonDecoder())
+                .encoder(new JacksonEncoder())
+                .logger(logger)
+                .logLevel(Logger.Level.FULL)
+                .target(RangerTarget.<TestApi>builder().type(TestApi.class).environment("test").namespace("test").service("test").curator(curator).objectMapper(objectMapper).rootPathPrefix("apis/ks").build());
+        val result = api.test();
+        assertTrue(result.message.equalsIgnoreCase("test"));
+    }
+
+    @Test
     public void testFailureHttpCall() throws Exception {
         stubFor(get(urlEqualTo("/v1/test"))
                 .willReturn(aResponse()


### PR DESCRIPTION
Problem:
When a call using feign-ranger is done for `@RequestLine("GET /v1/test")`,
with the current implementation the call gets translated to:
`http://Address-from-ranger-for-backend-service/v1/test`
If we need to translate this call to a call accepted by gateway, it
should become:
`http://Address-from-ranger-for-gateway-service/apis/backend/v1/test`.

When the client calls have to pass through api gateways which expect
a prefix, each http call needs to have a prefix that will be intercepted
by the api gateway which processes the request based on the prefix and
calls the actual backend where this call is intended to go. It would be
better to have this capability in feign-ranger.

Fix:
Implement capability to add rootPathPrefix as a builder argument to
facilitate this functionality.

Signed-off-by: Pranith Kumar K <pranith.karampuri@phonepe.com>